### PR TITLE
fix: 🐛 Fix missing python on Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 An Ansible Role that installs [Caldera Server](https://caldera.mitre.org/) main branch on linux .
 
-
 ## Requirements
 
 - Linux server
@@ -15,10 +14,10 @@ An Ansible Role that installs [Caldera Server](https://caldera.mitre.org/) main 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```yaml
-# tag or SHA-1 hash
+# SHA-1 hash of the commit
 ludus_caldera_git: b24f6e7a99cab19cbf417009bda9b9c6c81abc31
 
-# User
+# User password
 ludus_caldera_admin_pwd: 'admin'
 ludus_caldera_red_pwd: 'red'
 ludus_caldera_blue_pwd: 'blue'

--- a/tasks/caldera.yml
+++ b/tasks/caldera.yml
@@ -52,3 +52,8 @@
       interval: 1m30s
       timeout: 10s
       retries: 3
+
+- name: Touch the .finish file
+  ansible.builtin.file:
+    path: "/opt/caldera_{{ ludus_caldera_git }}.finish"
+    state: touch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # https://caldera.readthedocs.io/en/latest/Installing-Caldera.html
 
-- name: Check that /opt/caldera exists
+- name: Check that finish file exists
   stat:
-    path: /opt/caldera
+    path: "/opt/caldera_{{ ludus_caldera_git }}.finish"
   register: stat_result   
 
 - name: Install Caldera


### PR DESCRIPTION
- Add missing python parts on Debian 12
- Add finish file if only caldara start

close #9 

On Debian 12 :

![image](https://github.com/user-attachments/assets/cfaf4ec7-d749-4df4-ae2b-d1cd315e6d3c)
